### PR TITLE
Basic provisioning support.

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,13 +1,27 @@
 "use strict";
-let cli = require("../lib/cli");
-let co  = require("co");
+let cli          = require("../lib/cli");
+let co           = require("co");
+let ServiceMaker = require("../lib/ServiceMaker");
+
+const DEFAULT_URL = "https://dev-servicemaker.bwrnd.com";
+
+function clientFactory (config, options) {
+  options = Object.create(options) || {};
+
+  options.url = options.url || config.get("url", DEFAULT_URL);
+  if (!("username" in options) && !("password" in options)) {
+    options.token = config.get("token");
+  }
+
+  return new ServiceMaker(options);
+}
 
 co(function* () {
-	try {
-		yield cli.run(process.argv);
-	}
-	catch (error) {
-		console.error(error.message);
-		process.exit(1);
-	}
+  try {
+    yield cli.run(clientFactory, process.argv);
+  }
+  catch (error) {
+    console.error(error.message);
+    process.exit(1);
+  }
 })();

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -6,7 +6,7 @@ let ServiceMaker = require("../lib/ServiceMaker");
 const DEFAULT_URL = "https://dev-servicemaker.bwrnd.com";
 
 function clientFactory (config, options) {
-  options = Object.create(options) || {};
+  options = options ? Object.create(options) : {};
 
   options.url = options.url || config.get("url", DEFAULT_URL);
   if (!("username" in options) && !("password" in options)) {

--- a/lib/ServiceMaker.js
+++ b/lib/ServiceMaker.js
@@ -1,9 +1,10 @@
 "use strict";
-let debug   = require("debug")("service_maker_cli:ServiceMaker");
-let q       = require("q");
-let request = require("superagent");
-let url     = require("url");
-let _       = require("lodash");
+let debug     = require("debug")("service_maker_cli:ServiceMaker");
+let q         = require("q");
+let request   = require("superagent");
+let url       = require("url");
+let utilities = require("./utilities");
+let _         = require("lodash");
 
 function Client (options) {
   let token = options.token;
@@ -17,16 +18,39 @@ function Client (options) {
     apiRequest.set("Authorization", "token " + token);
   }
 
+  function resolveUrl (endpoint) {
+    if (endpoint.match(/^http:\/\//)) {
+      return endpoint;
+    }
+
+    return url.resolve(options.url, endpoint);
+  }
+
+  function handleErrors (response) {
+    if (response.statusCode === 403) {
+      throw new Error("Invalid access token");
+    }
+  }
+
   this.get = function* (endpoint) {
-    let clientRequest = request.get(url.resolve(options.url, endpoint));
+    let clientRequest = request.get(resolveUrl(endpoint));
     let response;
 
     yield authorizeRequest(clientRequest);
     response = yield q.ninvoke(clientRequest, "end");
+    handleErrors(response);
 
-    if (response.statusCode === 403) {
-      throw new Error("Invalid access token");
-    }
+    return response;
+  };
+
+  this.post = function* (endpoint, payload) {
+    let clientRequest = request.post(resolveUrl(endpoint)).send(payload);
+    let response;
+
+    debug("post '%j' to '%s'", payload, endpoint);
+    yield authorizeRequest(clientRequest);
+    response = yield q.ninvoke(clientRequest, "end");
+    handleErrors(response);
 
     return response;
   };
@@ -53,6 +77,33 @@ function Client (options) {
 }
 
 function Services (client) {
+  const PROVISIONING_TIMEOUT = 5 * 60 * 1000;   // 5 minutes
+
+  this.create = function* (type) {
+    let provision = yield client.post("/services", { type : type });
+    let job       = yield client.get(provision.body.job.url);
+    let start     = Date.now();
+    let service;
+
+    while (job.body.status === "PENDING") {
+      if (Date.now() - start > PROVISIONING_TIMEOUT) {
+        throw new Error("Provisioning timed out");
+      }
+
+      yield utilities.wait(1);
+      job = yield client.get(provision.body.job.url);
+    }
+
+    if (job.body.status === "COMPLETE") {
+      service = yield client.get(job.body.service.url);
+    }
+    else {
+      throw new Error("Provisioning failed");
+    }
+
+    return service.body;
+  };
+
   this.describe = function* () {
     let response = yield client.get("/services");
 
@@ -69,7 +120,7 @@ function ServiceTypes (client) {
 }
 
 function ServiceMaker (options) {
-  let client = new Client(options);
+  let client = new Client(options || {});
 
   this.login        = client.login.bind(client);
   this.services     = new Services(client);

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -47,6 +47,18 @@ function printTable () {
   console.log(table.toString());
 }
 
+function printObject (object) {
+  let table = new Table();
+
+  _.each(object, function (value, key) {
+    let entry = {};
+
+    entry[key] = value;
+    table.push(entry);
+  });
+  console.log(table.toString());
+}
+
 function* prompt (message, silent) {
   let result = yield read.bind(
     null,
@@ -64,8 +76,25 @@ prompt.password = function* (message) {
   return yield prompt(message, true);
 };
 
+let createService = co(function* (type) {
+  let client = program.client(new Config(configPath()));
+  let output = {};
+  let service;
+
+  try {
+    service = yield client.services.create(type);
+  }
+  catch (error) {
+    handleError(error);
+  }
+
+  output.type = service.type;
+  _.assign(output, service.data);
+  printObject(output);
+});
+
 let listServices = co(function* () {
-  let client = program.client(new Config(configPath));
+  let client = program.client(new Config(configPath()));
   let services;
 
   try {
@@ -125,6 +154,11 @@ program
   .command("services")
   .description("List the available services.")
   .action(handle(listServices));
+
+program
+  .command("service-create <type>")
+  .description("Create a new service instance.")
+  .action(handle(createService));
 
 program
   .command("types")

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -6,22 +6,11 @@ let path         = require("path");
 let program      = require("commander");
 let q            = require("q");
 let read         = require("read");
-let ServiceMaker = require("../lib/ServiceMaker");
 let Table        = require("cli-table");
 let _            = require("lodash");
 
-const DEFAULT_URL = "https://dev-servicemaker.bwrnd.com";
-
 function configPath () {
   return path.join(process.env.HOME, ".service_maker");
-}
-
-function createClient () {
-  let config = new Config(configPath());
-  let token  = config.get("token");
-  let url    = config.get("url", DEFAULT_URL);
-
-  return new ServiceMaker({ token : token, url : url });
 }
 
 function done (error) {
@@ -76,7 +65,7 @@ prompt.password = function* (message) {
 };
 
 let listServices = co(function* () {
-  let client = createClient();
+  let client = program.client(new Config(configPath));
   let services;
 
   try {
@@ -92,7 +81,7 @@ let listServices = co(function* () {
 });
 
 let listTypes = co(function* () {
-  let client = createClient();
+  let client = program.client(new Config(configPath));
   let types;
 
   try {
@@ -110,15 +99,10 @@ let login = co(function* () {
   let config   = new Config(configPath());
   let username = yield prompt("username");
   let password = yield prompt.password("password");
-  let url      = config.get("url", DEFAULT_URL);
   let token;
 
-  debug("attempting to login to '%s'", url);
-  let client = new ServiceMaker({
-    username : username,
-    password : password,
-    url      : url
-  });
+  debug("attempting to login");
+  let client = program.client(config, { username : username, password : password });
 
   try {
     token = yield client.login();
@@ -154,11 +138,10 @@ program.on("*", function (command) {
 
 module.exports = {
 
-  defaultUrl : DEFAULT_URL,
-
-  run : function (args) {
+  run : function (factory, args) {
     let deferred = q.defer();
 
+    program.client = factory;
     program.once("done", deferred.makeNodeResolver());
     program.parse(args);
 

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -1,0 +1,13 @@
+"use strict";
+let debug = require("debug")("service_maker_cli:utilities");
+
+module.exports = {
+
+  wait : function* (seconds) {
+    debug("waiting %d seconds", seconds);
+    yield function (done) {
+      setTimeout(done, seconds * 1000);
+    };
+  }
+
+};

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "koa-basic-auth": "^1.1.1",
     "koa-router": "^3.1.4",
     "mocha": "^1.20.1",
-    "nock": "^0.36.2"
+    "nock": "^0.36.2",
+    "sinon": "^1.10.2"
   },
   "dependencies": {
     "cli-table": "^0.3.0",

--- a/test/utilities_spec.js
+++ b/test/utilities_spec.js
@@ -1,0 +1,26 @@
+"use strict";
+let expect    = require("chai").expect;
+let sinon     = require("sinon");
+let utilities = require("../lib/utilities");
+
+describe("The utility function", function () {
+  describe("wait", function () {
+    let timeoutStub;
+
+    before(function* () {
+      timeoutStub = sinon.stub(global, "setTimeout", function (task) {
+        process.nextTick(task);
+      });
+
+      yield utilities.wait(5);
+    });
+
+    after(function () {
+      timeoutStub.restore();
+    });
+
+    it("yields for a specified number of seconds", function () {
+      expect(timeoutStub.calledWithMatch(sinon.match.func, 5000), "timeout").to.be.true;
+    });
+  });
+});


### PR DESCRIPTION
This change makes it possible to provision `demo` service instances from the command line. Support for provider specific options is not provided. For this reason (and possibly others), provisioning of more sophisticated service types is currently not functional.
